### PR TITLE
Update to .netcore1.1 and update packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,17 @@ before_install:
 
 install:
 # Install .net using linux CLI commands
-  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' 
-  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
   - sudo apt-get update
-  - sudo apt-get install -qq dotnet-dev-1.0.0-preview2-003121
+  - sudo apt-get install dotnet-dev-1.0.0-preview2-1-003177
 
 script:
   - dotnet restore
   - dotnet build src/Speakr.TalksApi
   - dotnet build tests/Speakr.TalksApi.Tests
-  - dotnet test tests/Speakr.TalksApi.Tests -f netcoreapp1.0
-  - dotnet test tests/Speakr.TalksApi.AcceptanceTests -f netcoreapp1.0
+  - dotnet test tests/Speakr.TalksApi.Tests
+  - dotnet test tests/Speakr.TalksApi.AcceptanceTests
 
 before_deploy:
   - zip -r $(date +'TalksApi-%F').zip *

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/src/Speakr.TalksApi/project.json
+++ b/src/Speakr.TalksApi/project.json
@@ -1,37 +1,33 @@
 {
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "platform"
     },
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
-    "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.0.0",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
     "Swashbuckle": "6.0.0-beta902",
     "Dapper": "1.50.2",
-    "MySql.Data": "7.0.5-IR21",
-    "MySql.Data.EntityFrameworkCore": "7.0.5-IR21",
-    "Microsoft.EntityFrameworkCore": "1.0.1",
-    "System.Linq": "4.1.0",
     "Swashbuckle.Swagger": "6.0.0-beta902",
     "Swashbuckle.SwaggerGen": "6.0.0-beta902",
-    "Swashbuckle.SwaggerUi": "6.0.0-beta902"
+    "Swashbuckle.SwaggerUi": "6.0.0-beta902",
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.1.0-preview4-final",
+    "Microsoft.EntityFrameworkCore": "1.1.0",
+    "MySql.Data": "7.0.6-IR31",
+    "MySql.Data.EntityFrameworkCore": "7.0.6-IR31",
+    "System.Linq": "4.3.0",
+    "Microsoft.AspNetCore.Diagnostics": "1.1.0",
+    "Microsoft.AspNetCore.Mvc": "1.1.0",
+    "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.1.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.1.0"
   },
 
   "tools": {
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
   },
 
   "frameworks": {
-    "netcoreapp1.0": {
-      "imports": [
-        "dotnet5.6",
-        "portable-net45+win8"
-      ]
-    },
+    "netcoreapp1.1": {
+    }
   },
 
   "buildOptions": {

--- a/tests/Speakr.TalksApi.AcceptanceTests/project.json
+++ b/tests/Speakr.TalksApi.AcceptanceTests/project.json
@@ -5,25 +5,23 @@
     "Speakr.TalksApi": {
       "target": "project"
     },
+    "Microsoft.NETCore.App": {
+      "version": "1.1.0",
+      "type": "platform"
+    },
     "NUnit": "3.5.0",
-    "Microsoft.AspNetCore.TestHost": "1.0.0",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "Microsoft.AspNetCore.TestHost": "1.1.0"
   },
 
   "testRunner": "nunit",
 
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
-        "netcoreapp1.0",
+        "netcoreapp1.1",
         "portable-net45+win8"
-      ],
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.0.0-*",
-          "type": "platform"
-        }
-      }
+      ]
     }
   }
 }

--- a/tests/Speakr.TalksApi.AcceptanceTests/project.json
+++ b/tests/Speakr.TalksApi.AcceptanceTests/project.json
@@ -11,7 +11,8 @@
     },
     "NUnit": "3.5.0",
     "dotnet-test-nunit": "3.4.0-beta-3",
-    "Microsoft.AspNetCore.TestHost": "1.1.0"
+    "Microsoft.AspNetCore.TestHost": "1.1.0",
+    "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
   },
 
   "testRunner": "nunit",

--- a/tests/Speakr.TalksApi.Tests/project.json
+++ b/tests/Speakr.TalksApi.Tests/project.json
@@ -5,26 +5,25 @@
     "Speakr.TalksApi": {
       "target": "project"
     },
+    "Microsoft.NETCore.App": {
+      "version": "1.1.0",
+      "type": "platform"
+    },
     "NUnit": "3.5.0",
-    "Microsoft.AspNetCore.TestHost": "1.0.0",
-    "dotnet-test-nunit": "3.4.0-beta-2",
-    "FakeItEasy": "2.4.0-netstd-build000033"
+    "FakeItEasy": "3.0.0-beta002-build000071",
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "Microsoft.AspNetCore.TestHost": "1.1.0",
+    "Microsoft.DotNet.InternalAbstractions": "1.0.500-preview2-1-003177"
   },
 
   "testRunner": "nunit",
 
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
-        "netcoreapp1.0",
+        "netcoreapp1.1",
         "portable-net45+win8"
-      ],
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.0.0-*",
-          "type": "platform"
-        }
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
Damned the tests now need this InternalAbstraction packages or the test runner can't find them in VS.
Possibly a tooling bug